### PR TITLE
feat: Adapt to changes of Node-Traits in flowrs

### DIFF
--- a/src/nodes/io/file.rs
+++ b/src/nodes/io/file.rs
@@ -10,7 +10,7 @@ pub struct FileWriterConfig {
     file: String
 }
 
-#[derive(Clone)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct FileReaderConfig {
     file: String
 }
@@ -125,7 +125,4 @@ fn test_file_read_and_write() {
 
     //println!("{:?}", odd_res_nums);
     //println!("{:?}", even_res_nums);
-    
-   
-    
 }

--- a/src/nodes/value.rs
+++ b/src/nodes/value.rs
@@ -33,7 +33,7 @@ impl<I> Node for ValueNode<I>
 where
     I: Clone + Send,
 {
-    fn on_ready(&self) -> Result<(), ReadyError>{
+    fn on_ready(&mut self) -> Result<(), ReadyError>{
         self.output.clone().send(self.value.clone()).map_err(|e| ReadyError::Other(e.into()))?;   
         Ok(())
     }

--- a/tests/nodes/test_node.rs
+++ b/tests/nodes/test_node.rs
@@ -95,15 +95,15 @@ where
     I2: Clone + Send + 'static,
     O: Clone + Send + 'static,
 {
-    fn on_init(&self) -> Result<(), InitError>{ 
+    fn on_init(&mut self) -> Result<(), InitError>{ 
         Ok(())
     }
 
-    fn on_ready(&self)   -> Result<(), ReadyError>{
+    fn on_ready(&mut self)   -> Result<(), ReadyError>{
         Ok(())
     }
 
-    fn on_shutdown(&self)  -> Result<(), ShutdownError> {
+    fn on_shutdown(&mut self)  -> Result<(), ShutdownError> {
         Ok(())
     }
 

--- a/tests/nodes/test_value.rs
+++ b/tests/nodes/test_value.rs
@@ -10,7 +10,7 @@ mod nodes {
     #[test]
     fn should_send_on_ready() -> Result<(), anyhow::Error> {
         let change_observer: ChangeObserver = ChangeObserver::new(); 
-        let node = ValueNode::new(42, Some(&change_observer));
+        let mut node = ValueNode::new(42, Some(&change_observer));
         let mock_output = Edge::new();
         connect(node.output.clone(), mock_output.clone());
         let _ = node.on_ready();

--- a/tests/sched/test_sched.rs
+++ b/tests/sched/test_sched.rs
@@ -27,7 +27,7 @@ impl DummyNode {
 }
 
 impl Node for DummyNode {
-    fn on_init(&self)-> Result<(), InitError> {
+    fn on_init(&mut self)-> Result<(), InitError> {
         
         if self.err_on_init {
             let _file = File::open("").map_err(|err| InitError::Other(err.into()))?;


### PR DESCRIPTION
Considering a statefull node, non-mutable on_init, on_ready or on_shutdown are not allowing any states to be stored or modified. Due to that flowrs repository was changed. These changes adapt to that.